### PR TITLE
add initial test-kitchen support and emeril support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.kitchen/
+.kitchen.local.yml
+tmp
+.librarian
+Cheffile.lock

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,0 +1,24 @@
+---
+driver:
+  name: vagrant
+
+provisioner:
+  name: chef_zero
+
+platforms:
+  - name: ubuntu-12.04
+    run_list:
+    - recipe[ubuntu]
+  - name: centos-6.4
+    run_list:
+    - recipe[yum-epel]
+
+suites:
+  - name: default
+    run_list:
+      - recipe[nginx_simplecgi::default]
+    attributes: {
+      "nginx_simplecgi": {
+        "cgi": true
+      }
+    }

--- a/Cheffile
+++ b/Cheffile
@@ -1,0 +1,8 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+site 'http://community.opscode.com/api/v1'
+
+cookbook 'nginx_simplecgi', path:'.'
+
+cookbook 'ubuntu'
+cookbook 'yum'

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,12 @@
+source "https://rubygems.org"
+
+gem 'rake'
+gem 'librarian-chef'
+gem 'emeril', :group => :release
+
+group :test do
+  gem 'test-kitchen'
+  gem 'kitchen-vagrant'
+  gem 'kitchen-docker'
+end
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,106 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    archive-tar-minitar (0.5.2)
+    chef (11.10.4)
+      chef-zero (~> 1.7, >= 1.7.2)
+      diff-lcs (~> 1.2, >= 1.2.4)
+      erubis (~> 2.7)
+      highline (~> 1.6, >= 1.6.9)
+      json (>= 1.4.4, <= 1.8.1)
+      mime-types (~> 1.16)
+      mixlib-authentication (~> 1.3)
+      mixlib-cli (~> 1.4)
+      mixlib-config (~> 2.0)
+      mixlib-log (~> 1.3)
+      mixlib-shellout (~> 1.3)
+      net-ssh (~> 2.6)
+      net-ssh-multi (~> 1.1)
+      ohai (~> 6.0)
+      pry (~> 0.9)
+      puma (~> 1.6)
+      rest-client (>= 1.0.4, < 1.7.0)
+      yajl-ruby (~> 1.1)
+    chef-zero (1.7.3)
+      hashie (~> 2.0)
+      json
+      mixlib-log (~> 1.3)
+      moneta (< 0.7.0)
+      rack
+    coderay (1.1.0)
+    diff-lcs (1.2.5)
+    emeril (0.7.0)
+      chef (> 0.10.10)
+    erubis (2.7.0)
+    hashie (2.0.5)
+    highline (1.6.21)
+    ipaddress (0.8.0)
+    json (1.8.1)
+    kitchen-docker (0.13.0)
+      test-kitchen (>= 1.0.0.rc.2)
+    kitchen-vagrant (0.14.0)
+      test-kitchen (~> 1.0)
+    librarian (0.1.2)
+      highline
+      thor (~> 0.15)
+    librarian-chef (0.0.2)
+      archive-tar-minitar (>= 0.5.2)
+      chef (>= 0.10)
+      librarian (~> 0.1.0)
+    method_source (0.8.2)
+    mime-types (1.25.1)
+    mixlib-authentication (1.3.0)
+      mixlib-log
+    mixlib-cli (1.4.0)
+    mixlib-config (2.1.0)
+    mixlib-log (1.6.0)
+    mixlib-shellout (1.3.0)
+    moneta (0.6.0)
+    net-scp (1.1.2)
+      net-ssh (>= 2.6.5)
+    net-ssh (2.8.0)
+    net-ssh-gateway (1.2.0)
+      net-ssh (>= 2.6.5)
+    net-ssh-multi (1.2.0)
+      net-ssh (>= 2.6.5)
+      net-ssh-gateway (>= 1.2.0)
+    ohai (6.20.0)
+      ipaddress
+      mixlib-cli
+      mixlib-config
+      mixlib-log
+      mixlib-shellout
+      systemu (~> 2.5.2)
+      yajl-ruby
+    pry (0.9.12.6)
+      coderay (~> 1.0)
+      method_source (~> 0.8)
+      slop (~> 3.4)
+    puma (1.6.3)
+      rack (~> 1.2)
+    rack (1.5.2)
+    rake (10.2.1)
+    rest-client (1.6.7)
+      mime-types (>= 1.16)
+    safe_yaml (1.0.1)
+    slop (3.5.0)
+    systemu (2.5.2)
+    test-kitchen (1.2.1)
+      mixlib-shellout (~> 1.2)
+      net-scp (~> 1.1)
+      net-ssh (~> 2.7)
+      safe_yaml (~> 1.0)
+      thor (~> 0.18)
+    thor (0.19.1)
+    yajl-ruby (1.2.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  emeril
+  kitchen-docker
+  kitchen-vagrant
+  librarian-chef
+  rake
+  test-kitchen


### PR DESCRIPTION
Allows for tests to be enhanced and adds test-kitchen. 
Use emeril to push cookbook releases to the community site. 
