### PR TITLE
fix: migrate to Policyfile

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -21,4 +21,4 @@ jobs:
       - name: Install Chef
         uses: actionshub/chef-install@main
       - name: Install cookbooks
-        run: berks install
+        run: chef install Policyfile.rb

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,10 @@
-# nginx_simplecgi Limitations
+# nginx_simplecgi Agent Notes
 
 This cookbook manages SimpleCGI dispatcher scripts for NGINX and uses OS packages for FastCGI support.
+
+## Dependency Management
+
+Use `chef install Policyfile.rb` to resolve cookbook dependencies. The Policyfile uses GitHub sources for sous-chefs cookbook dependencies to avoid Supermarket availability issues during CI and local validation.
 
 ## Platform Support
 

--- a/Berksfile
+++ b/Berksfile
@@ -1,7 +1,0 @@
-source 'https://supermarket.chef.io'
-
-metadata
-
-group :integration do
-  cookbook 'test', path: 'test/cookbooks/test'
-end

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+name 'nginx_simplecgi'
+
+run_list 'test::default'
+
+cookbook 'nginx_simplecgi', path: '.'
+cookbook 'test', path: './test/cookbooks/test'
+
+cookbook 'nginx', git: 'https://github.com/sous-chefs/nginx.git', branch: 'main'
+cookbook 'perl', git: 'https://github.com/sous-chefs/perl.git', branch: 'main'
+cookbook 'yum-epel', git: 'https://github.com/sous-chefs/yum-epel.git', branch: 'main'
+
+Dir.children('./test/cookbooks/test/recipes').grep(/\.rb\z/).sort.each do |recipe|
+  recipe_name = File.basename(recipe, '.rb')
+  named_run_list recipe_name.to_sym, "test::#{recipe_name}"
+end

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ This cookbook is resource-only. The legacy recipes and attributes have been remo
 * [nginx_simplecgi_cgi_dispatcher](documentation/cgi_dispatcher.md)
 * [nginx_simplecgi_php_dispatcher](documentation/php_dispatcher.md)
 * [Migration guide](migration.md)
-* [Limitations](LIMITATIONS.md)
+* [Agent notes](AGENTS.md)
 
 ```ruby
 nginx_simplecgi_cgi_dispatcher 'default' do

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -4,7 +4,9 @@ driver:
   chef_version: <%= ENV['CHEF_VERSION'] || 'current' %>
 
 transport: { name: dokken }
-provisioner: { name: dokken }
+provisioner:
+  name: dokken
+  policyfile: Policyfile.rb
 
 platforms:
   - name: almalinux-9

--- a/kitchen.exec.yml
+++ b/kitchen.exec.yml
@@ -2,6 +2,12 @@
 driver: { name: exec }
 transport: { name: exec }
 
+provisioner:
+  name: chef_infra
+  chef_omnibus_install: false
+  sudo: true
+  policyfile: Policyfile.rb
+
 platforms:
   - name: macos-latest
   - name: windows-latest

--- a/kitchen.global.yml
+++ b/kitchen.global.yml
@@ -1,6 +1,6 @@
 ---
 provisioner:
-  name: chef_infra
+  name: policyfile_zero
   product_name: chef
   product_version: <%= ENV['CHEF_VERSION'] || 'latest' %>
   channel: stable
@@ -10,6 +10,7 @@ provisioner:
   multiple_converge: <%= ENV['MULTIPLE_CONVERGE'] || 2 %>
   deprecations_as_errors: true
   log_level: <%= ENV['CHEF_LOG_LEVEL'] || 'auto' %>
+  policyfile: Policyfile.rb
 
 verifier:
   name: inspec

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -3,11 +3,12 @@ driver:
   name: vagrant
 
 provisioner:
-  name: chef_infra
+  name: policyfile_zero
   product_name: chef
   enforce_idempotency: true
   multiple_converge: 2
   deprecations_as_errors: true
+  policyfile: Policyfile.rb
 
 verifier:
   name: inspec
@@ -19,8 +20,8 @@ platforms:
 
 suites:
   - name: default
-    run_list:
-      - recipe[test::default]
+    provisioner:
+      named_run_list: default
     verifier:
       inspec_tests:
         - test/integration/default

--- a/resources/cgi_dispatcher.rb
+++ b/resources/cgi_dispatcher.rb
@@ -14,7 +14,7 @@ action_class do
 end
 
 action :create do
-  include_recipe 'yum-epel::default' if platform_family?('rhel')
+  yum_epel 'default' if platform_family?('rhel')
 
   package dispatcher_packages
 

--- a/resources/php_dispatcher.rb
+++ b/resources/php_dispatcher.rb
@@ -16,7 +16,7 @@ end
 
 action :create do
   if spawn_fcgi_available?
-    include_recipe 'yum-epel::default' if platform_family?('rhel')
+    yum_epel 'default' if platform_family?('rhel')
 
     package dispatcher_packages + %w(spawn-fcgi)
     package php_packages

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'chefspec'
-require 'chefspec/berkshelf'
+require 'chefspec/policyfile'
 require_relative '../libraries/helpers'
 
 RSpec.configure do |config|


### PR DESCRIPTION
## Summary
- replace Berkshelf with Policyfile dependency resolution using HTTPS GitHub cookbook sources
- switch ChefSpec and Kitchen/Copilot setup to Policyfile-aware commands/configuration
- move LIMITATIONS.md guidance into AGENTS.md and update the README link
- replace stale yum-epel recipe inclusion with the current yum_epel resource for GitHub dependency compatibility

## Validation
- env HOME=/private/tmp/sous-chefs-policyfile-nginx-simplecgi-chef-home CHEF_LICENSE=accept-silent /opt/chef-workstation/bin/chef install Policyfile.rb
- cookstyle
- env HOME=/private/tmp/sous-chefs-policyfile-nginx-simplecgi-chef-home CHEF_LICENSE=accept-silent /opt/chef-workstation/bin/chef exec rspec --format documentation
- env HOME=/private/tmp/sous-chefs-policyfile-nginx-simplecgi-chef-home CHEF_LICENSE=accept-silent KITCHEN_LOCAL_YAML=kitchen.dokken.yml kitchen test default-ubuntu-2404 --destroy=always
- KITCHEN_LOCAL_YAML=kitchen.dokken.yml kitchen list
- git diff --check
- actionlint
- yamllint .
- markdownlint-cli2 "**/*.md" "#CHANGELOG.md"